### PR TITLE
Add dynamic .vet name fetching

### DIFF
--- a/shared/knownAddresses.js
+++ b/shared/knownAddresses.js
@@ -1327,6 +1327,7 @@ async function getVetNameForContract(address) {
     short: tld,
     long: name
   }
+  PRETTY_KNOWN_CONTRACTS[address] = name
 
   // return the newly fetched data
   return KNOWN_CONTRACTS[address]

--- a/shared/knownAddresses.js
+++ b/shared/knownAddresses.js
@@ -1257,7 +1257,14 @@ const KNOWN_ADDRESSES = {
 }
 
 function getKnownContract(address, shortOrLong) {
-  if (!KNOWN_CONTRACTS[address]) return
+  if (!KNOWN_CONTRACTS[address]) {
+    // suggestion:
+    // less intrusive action would be fetching for the next time, not blocking first time display
+    // otherwise we could move the getKnownContract to be async in all places
+    void getVetNameForContract(address)
+    return
+  }
+
   return typeof KNOWN_CONTRACTS[address] === 'string'
     ? KNOWN_CONTRACTS[address]
     : KNOWN_CONTRACTS[address][shortOrLong]
@@ -1269,6 +1276,60 @@ function getShortKnownContract(address) {
 
 function getLongKnownContract(address) {
   return getKnownContract(address, 'long')
+}
+
+
+const fetchedVetAddresses = new Set()
+async function getVetNameForContract(address) {
+  // fetch every address only once
+  if (fetchedVetAddresses.has(address) || KNOWN_CONTRACTS[address]) { return }
+  fetchedVetAddresses.add(address)
+
+  // read name for address
+  try {
+    const [name] = await fetch('https://api.vechain.energy/v1/call/main', {
+      method: 'POST',
+      body: JSON.stringify({
+        "clauses": [
+          {
+            "to": "0xA11413086e163e41901bb81fdc5617c975Fa5a1A",
+            "abi": {
+              "inputs": [
+                { "internalType": "address[]", "name": "addresses", "type": "address[]" }
+              ],
+              "name": "getNames",
+              "outputs": [
+                { "internalType": "string[]", "name": "names", "type": "string[]" }
+              ],
+              "stateMutability": "view",
+              "type": "function"
+            },
+            "args": [
+              [address]
+            ]
+          }
+        ]
+      })
+    }).then(res => res.json())
+  }
+
+  // just ignore errors, we can re-fetch on next start
+  catch {
+    return
+  }
+  if (!name) { return }
+
+  // extract tld from name, for exmaple vtho.swap.energy.vet => energy.vet
+  const tld = name.split('.').slice(-2).join('.')
+
+  // store in results KNOWN_CONTRACTS
+  KNOWN_CONTRACTS[address] = {
+    short: tld,
+    long: name
+  }
+
+  // return the newly fetched data
+  return KNOWN_CONTRACTS[address]
 }
 
 const PRETTY_KNOWN_CONTRACTS = {}


### PR DESCRIPTION
This PR adds the ability to dynamically name addresses based on their .vet name

- If an address is not in KNOWN_CONTRACTS
- The .vet name will be loaded asynchronously
- The first occurrence will not use a .vet name
- Subsequent occurrences will find an entry in KNOWN_CONTRACTS
- If a name exists, the name will be added to KNOWN_CONTRACTS
- Each address name will only be tried once

Known issues:

- If the API fails, it will not be able to detect the name until resturn
- If an address is once read, name changes are only detected after an application restart
- First detection of a name will still be anon, this is to ensure no changes to the current function handling